### PR TITLE
Fix bug with float to charlist in Elixir 1.1 and 1.2

### DIFF
--- a/test/renamed_defs_test.exs
+++ b/test/renamed_defs_test.exs
@@ -18,12 +18,12 @@ defmodule RenamedDefsTest do
 
   test "Float.to_charlist and Float.to_char_list" do
     assert capture_io(:stderr, fn ->
-      {'-2.7', _} = Code.eval_string("""
+      {'-2.7' ++ _, _} = Code.eval_string("""
       import ExCompatible
       safe(Float.to_charlist(-2.7))
       """)
 
-      {'1.99', _} = Code.eval_string("""
+      {'1.99' ++ _, _} = Code.eval_string("""
       import ExCompatible
       safe(Float.to_char_list(1.99))
       """)

--- a/test/renamed_defs_test.exs
+++ b/test/renamed_defs_test.exs
@@ -18,15 +18,17 @@ defmodule RenamedDefsTest do
 
   test "Float.to_charlist and Float.to_char_list" do
     assert capture_io(:stderr, fn ->
-      {'-2.7' ++ _, _} = Code.eval_string("""
+      {result, _} = Code.eval_string("""
       import ExCompatible
       safe(Float.to_charlist(-2.7))
       """)
+      assert List.to_float(result) == -2.7
 
-      {'1.99' ++ _, _} = Code.eval_string("""
+      {result, _} = Code.eval_string("""
       import ExCompatible
       safe(Float.to_char_list(1.99))
       """)
+      assert List.to_float(result) == 1.99
     end) == ""
   end
 


### PR DESCRIPTION
Prior to Elixir 1.3, `Float.to_char_list` results in lists like `'-2.70000000000000017764e+00'` instead of `'-2.7'`. This should fix our tests so we don't look for the exact match