### PR TITLE
Rename 'safe' to 'compatible' as this is less likely to cause conflicts

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,9 +21,9 @@ compiles on Elixir 1.1? You switch to using `String.to_char_list/1` instead,
 but now your compiler spits out annoying warnings on Elixir 1.5. What should
 you do?
 
-ExCompatible can inspect your Elixir version, and by using the `safe` macro, it
-will always inject the most appropriate version of a defition so your compiler
-stays happy.
+ExCompatible can inspect your Elixir version, and by using the `compatible`
+macro, it will always inject the most appropriate version of a defition so your
+compiler stays happy.
 
 **Note:** This project is still under heavy construction. Please check the to-do
 list further down, and we love contributors!
@@ -41,17 +41,17 @@ defp deps do
 end
 ```
 
-Then you will need to import the `safe/1` macro inside any modules in which
-you would like to use it. For example:
+Then you will need to import the `compatible/1` macro inside any modules in
+which you would like to use it. For example:
 
 ```elixir
 defmodule MyModule do
-  import ExCompatible, only: [safe: 1]
+  import ExCompatible, only: [compatible: 1]
 
   def my_def do
-    IO.puts safe(String.to_char_list("Hello world!"))
+    IO.puts compatible(String.to_char_list("Hello world!"))
 
-    safe do
+    compatible do
       Enum.partition([5, 4, 3, 2], fn(x) -> rem(x, 2) == 0 end)
     end
   end

--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ in your `mix.exs` file:
 ```elixir
 defp deps do
   [
-    {:ex_compatible, "~> 0.1"}
+    {:ex_compatible, "~> 0.2"}
   ]
 end
 ```

--- a/lib/ex_compatible.ex
+++ b/lib/ex_compatible.ex
@@ -11,17 +11,17 @@ defmodule ExCompatible do
 
   ## Examples
 
-      safe(String.to_char_list("Hello"))
+      compatible(String.to_char_list("Hello"))
 
-      safe do
+      compatible do
         String.to_char_list("Hello")
       end
   """
-  defmacro safe(do: quoted) do
-    Macro.postwalk(quoted, &make_safe/1)
+  defmacro compatible(do: quoted) do
+    Macro.postwalk(quoted, &make_compatible/1)
   end
 
-  defmacro safe(quoted) do
-    Macro.postwalk(quoted, &make_safe/1)
+  defmacro compatible(quoted) do
+    Macro.postwalk(quoted, &make_compatible/1)
   end
 end

--- a/lib/ex_compatible/build.ex
+++ b/lib/ex_compatible/build.ex
@@ -22,11 +22,11 @@ defmodule ExCompatible.Build do
         expression = choose_expression(old, new, arities)
 
         quote do
-          def make_safe(unquote(call_expression(old_module, old_def))) do
+          def make_compatible(unquote(call_expression(old_module, old_def))) do
             unquote(expression)
           end
 
-          def make_safe(unquote(call_expression(new_module, new_def))) do
+          def make_compatible(unquote(call_expression(new_module, new_def))) do
             unquote(expression)
           end
         end
@@ -34,10 +34,10 @@ defmodule ExCompatible.Build do
 
     quote do
       @doc false
-      @spec make_safe(Macro.t()) :: Macro.t()
+      @spec make_compatible(Macro.t()) :: Macro.t()
       unquote_splicing(defs)
 
-      def make_safe({call, ctx, args})
+      def make_compatible({call, ctx, args})
           when call in [:to_charlist, :to_char_list] do
         unquote(
           if macro_exported?(Kernel, :to_charlist, 1) do
@@ -48,7 +48,7 @@ defmodule ExCompatible.Build do
         )
       end
 
-      def make_safe(quoted) do
+      def make_compatible(quoted) do
         quoted
       end
     end

--- a/mix.exs
+++ b/mix.exs
@@ -7,7 +7,7 @@ defmodule ExCompatible.MixProject do
   versions as possible, while reducing the number of compiler warnings.
   """
 
-  @version "0.1.1"
+  @version "0.2.0"
   @project_url "https://github.com/thecodeboss/ex_compatible"
 
   def project do

--- a/test/renamed_defs_test.exs
+++ b/test/renamed_defs_test.exs
@@ -6,12 +6,12 @@ defmodule RenamedDefsTest do
     assert capture_io(:stderr, fn ->
       {'foo', _} = Code.eval_string("""
       import ExCompatible
-      safe(Atom.to_charlist(:foo))
+      compatible(Atom.to_charlist(:foo))
       """)
 
       {'bar', _} = Code.eval_string("""
       import ExCompatible
-      safe(Atom.to_char_list(:bar))
+      compatible(Atom.to_char_list(:bar))
       """)
     end) == ""
   end
@@ -20,13 +20,13 @@ defmodule RenamedDefsTest do
     assert capture_io(:stderr, fn ->
       {result, _} = Code.eval_string("""
       import ExCompatible
-      safe(Float.to_charlist(-2.7))
+      compatible(Float.to_charlist(-2.7))
       """)
       assert List.to_float(result) == -2.7
 
       {result, _} = Code.eval_string("""
       import ExCompatible
-      safe(Float.to_char_list(1.99))
+      compatible(Float.to_char_list(1.99))
       """)
       assert List.to_float(result) == 1.99
     end) == ""
@@ -36,12 +36,12 @@ defmodule RenamedDefsTest do
     assert capture_io(:stderr, fn ->
       {'-2', _} = Code.eval_string("""
       import ExCompatible
-      safe(Integer.to_charlist(-2))
+      compatible(Integer.to_charlist(-2))
       """)
 
       {'1', _} = Code.eval_string("""
       import ExCompatible
-      safe(Integer.to_char_list(1))
+      compatible(Integer.to_char_list(1))
       """)
     end) == ""
   end
@@ -50,12 +50,12 @@ defmodule RenamedDefsTest do
     assert capture_io(:stderr, fn ->
       {'foo', _} = Code.eval_string("""
       import ExCompatible
-      safe(to_charlist(:foo))
+      compatible(to_charlist(:foo))
       """)
 
       {'bar', _} = Code.eval_string("""
       import ExCompatible
-      safe(to_char_list(:bar))
+      compatible(to_char_list(:bar))
       """)
     end) == ""
   end
@@ -64,12 +64,12 @@ defmodule RenamedDefsTest do
     assert capture_io(:stderr, fn ->
       {'Hello', _} = Code.eval_string("""
       import ExCompatible
-      safe(List.Chars.to_charlist("Hello"))
+      compatible(List.Chars.to_charlist("Hello"))
       """)
 
       {'foo', _} = Code.eval_string("""
       import ExCompatible
-      safe(List.Chars.to_char_list(:foo))
+      compatible(List.Chars.to_char_list(:foo))
       """)
     end) == ""
   end
@@ -78,12 +78,12 @@ defmodule RenamedDefsTest do
     assert capture_io(:stderr, fn ->
       {'Hello', _} = Code.eval_string("""
       import ExCompatible
-      safe(String.to_charlist("Hello"))
+      compatible(String.to_charlist("Hello"))
       """)
 
       {'Hello', _} = Code.eval_string("""
       import ExCompatible
-      safe(String.to_char_list("Hello"))
+      compatible(String.to_char_list("Hello"))
       """)
     end) == ""
   end
@@ -92,7 +92,7 @@ defmodule RenamedDefsTest do
     assert capture_io(:stderr, fn ->
       {result, _} = Code.eval_string("""
       import ExCompatible
-      safe do
+      compatible do
         Enum.split_with([5, 4, 3, 2], fn(x) -> rem(x, 2) == 0 end)
       end
       """)
@@ -100,7 +100,7 @@ defmodule RenamedDefsTest do
 
       {result, _} = Code.eval_string("""
       import ExCompatible
-      safe do
+      compatible do
         Enum.partition([5, 4, 3, 2], fn(x) -> rem(x, 2) == 0 end)
       end
       """)
@@ -112,12 +112,12 @@ defmodule RenamedDefsTest do
     assert capture_io(:stderr, fn ->
       {"Hello", _} = Code.eval_string("""
       import ExCompatible
-      safe(String.trim("  \n Hello "))
+      compatible(String.trim("  \n Hello "))
       """)
 
       {"Hello", _} = Code.eval_string("""
       import ExCompatible
-      safe(String.strip("  \n Hello "))
+      compatible(String.strip("  \n Hello "))
       """)
     end) == ""
   end


### PR DESCRIPTION
After getting some feedback, `compatible` seemed like a better name.
I won't be making it backwards compatible, ironically, since this library is new and just started over the weekend.